### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 - `data/output` : Contains some results to test the code.
 
 ## Requirements
-The project has been developed using Python 3.7 with the packages contained in *requirements.txt*. We suggest to create a conda environment with
-`conda create --name CRep python=3.7.9 --no-default-packages`, activate it with `conda activate CRep`, and install all the dependencies by running (inside `CRep` directory):
+The project has been developed using Python 3.9 with the packages contained in *requirements.txt*. We suggest to create a virtual environment with
+`python3.9 -m venv --copies CRep`, activate it with `source CRep/bin/activate`, and install all the dependencies by running (inside `CRep` directory):
 
 `pip install -r requirements.txt`
 


### PR DESCRIPTION
Hi, I've changed the README to mention that the code works with python 3.9 and also to suggest that the virtual env should be created using `pyenv`. The reason why we might want to go from conda to to pyenv is to avoid unsolved package conflicts (it seems to be handling the conflicting packages in a better way). 

Last note: it works now on Python 3.9 :tada: . We could add a badge to the README if you like it (create an issue if so). 